### PR TITLE
feat: モバイルレスポンシブデザイン対応の実装

### DIFF
--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -1,2 +1,3 @@
 export { Button, buttonVariants } from "./button"
 export { Input } from "./input"
+export { MobileMenu } from "./mobile-menu"

--- a/app/components/ui/mobile-menu.tsx
+++ b/app/components/ui/mobile-menu.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import { Button } from "./button";
+
+interface MobileMenuProps {
+  user?: {
+    email?: string;
+  } | null;
+  onSignOut: () => void;
+  isSigningOut: boolean;
+}
+
+export function MobileMenu({ user, onSignOut, isSigningOut }: MobileMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => setIsOpen(!isOpen);
+  const closeMenu = () => setIsOpen(false);
+
+  return (
+    <>
+      {/* ハンバーガーメニューボタン */}
+      <button
+        onClick={toggleMenu}
+        className="md:hidden p-2 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        aria-label="メニューを開く"
+      >
+        <svg
+          className="h-6 w-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d={
+              isOpen
+                ? "M6 18L18 6M6 6l12 12" // X アイコン
+                : "M4 6h16M4 12h16M4 18h16" // ハンバーガーアイコン
+            }
+          />
+        </svg>
+      </button>
+
+      {/* オーバーレイ */}
+      {isOpen && (
+        <div
+          className="md:hidden fixed inset-0 bg-black bg-opacity-50 z-40"
+          onClick={closeMenu}
+        />
+      )}
+
+      {/* スライドアウトメニュー */}
+      <div
+        className={`md:hidden fixed top-0 right-0 h-full w-64 bg-white shadow-lg transform transition-transform duration-300 ease-in-out z-50 ${
+          isOpen ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex flex-col h-full">
+          {/* ヘッダー */}
+          <div className="flex items-center justify-between p-4 border-b border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-900">メニュー</h2>
+            <button
+              onClick={closeMenu}
+              className="p-2 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-100"
+              aria-label="メニューを閉じる"
+            >
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {/* ユーザー情報 */}
+          {user && (
+            <div className="p-4 border-b border-gray-200 bg-gray-50">
+              <p className="text-sm text-gray-600">ログイン中</p>
+              <p className="text-sm font-medium text-gray-900 truncate">
+                {user.email}
+              </p>
+            </div>
+          )}
+
+          {/* ナビゲーションリンク */}
+          <nav className="flex-1 p-4 space-y-2">
+            <Link
+              to="/dashboard"
+              onClick={closeMenu}
+              className="flex items-center px-4 py-3 text-base font-medium text-gray-700 rounded-md hover:text-gray-900 hover:bg-gray-100 transition-colors"
+            >
+              <svg
+                className="mr-3 h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                />
+              </svg>
+              ダッシュボード
+            </Link>
+
+            <Link
+              to="/bucket-list"
+              onClick={closeMenu}
+              className="flex items-center px-4 py-3 text-base font-medium text-gray-700 rounded-md hover:text-gray-900 hover:bg-gray-100 transition-colors"
+            >
+              <svg
+                className="mr-3 h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"
+                />
+              </svg>
+              やりたいこと一覧
+            </Link>
+
+            <Link
+              to="/public"
+              onClick={closeMenu}
+              className="flex items-center px-4 py-3 text-base font-medium text-gray-700 rounded-md hover:text-gray-900 hover:bg-gray-100 transition-colors"
+            >
+              <svg
+                className="mr-3 h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                />
+              </svg>
+              みんなのやりたいこと
+            </Link>
+          </nav>
+
+          {/* ログアウトボタン */}
+          <div className="p-4 border-t border-gray-200">
+            <Button
+              onClick={() => {
+                closeMenu();
+                onSignOut();
+              }}
+              variant="outline"
+              className="w-full"
+              disabled={isSigningOut}
+            >
+              {isSigningOut ? "ログアウト中..." : "ログアウト"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/features/bucket-list/components/achievement-stats.tsx
+++ b/app/features/bucket-list/components/achievement-stats.tsx
@@ -28,12 +28,12 @@ export function AchievementStats({ stats, className = "" }: AchievementStatsProp
   };
 
   return (
-    <div className={`bg-white rounded-lg shadow p-6 ${className}`}>
+    <div className={`bg-white rounded-lg shadow p-4 sm:p-6 ${className}`}>
       <h2 className="text-lg font-semibold text-gray-900 mb-6">達成状況</h2>
       
       {/* メイン達成率表示 */}
       <div className="text-center mb-6">
-        <div className="text-4xl font-bold text-gray-900 mb-2">
+        <div className="text-3xl sm:text-4xl font-bold text-gray-900 mb-2">
           {completionRate}%
         </div>
         <div className="text-sm text-gray-600 mb-4">

--- a/app/features/bucket-list/components/category-progress.tsx
+++ b/app/features/bucket-list/components/category-progress.tsx
@@ -37,7 +37,7 @@ export function CategoryProgress({ categories, items, className = "" }: Category
   }
 
   return (
-    <div className={`bg-white rounded-lg shadow p-6 ${className}`}>
+    <div className={`bg-white rounded-lg shadow p-4 sm:p-6 ${className}`}>
       <h2 className="text-lg font-semibold text-gray-900 mb-6">カテゴリ別達成状況</h2>
       
       <div className="space-y-4">

--- a/app/routes/bucket-list/bucket-list.tsx
+++ b/app/routes/bucket-list/bucket-list.tsx
@@ -225,12 +225,12 @@ export default function BucketListPage({ loaderData }: Route.ComponentProps) {
     <AuthenticatedLayout title="やりたいこと一覧">
       <div className="container mx-auto px-4 py-8 pb-12">
         <div className="mb-8">
-          <div className="flex justify-between items-center mb-4">
-            <h1 className="text-3xl font-bold text-gray-900">
+          <div className="flex flex-col space-y-3 mb-4 sm:flex-row sm:justify-between sm:items-center sm:space-y-0">
+            <h1 className="text-2xl md:text-3xl font-bold text-gray-900">
               やりたいこと一覧
             </h1>
             <Link to="/bucket-list/add">
-              <Button size="lg">
+              <Button size="lg" className="w-full sm:w-auto">
                 + 新しく追加
               </Button>
             </Link>
@@ -248,9 +248,9 @@ export default function BucketListPage({ loaderData }: Route.ComponentProps) {
           )}
 
           {/* フィルター・検索 */}
-          <div className="bg-white rounded-lg shadow p-6 mb-6">
+          <div className="bg-white rounded-lg shadow p-4 sm:p-6 mb-6">
             <h2 className="text-lg font-semibold text-gray-900 mb-4">フィルター・検索</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
               {/* 検索 */}
               <div>
                 <label htmlFor="search" className="block text-sm font-medium text-gray-700 mb-1">
@@ -358,7 +358,7 @@ export default function BucketListPage({ loaderData }: Route.ComponentProps) {
                       </span>
                     )}
                   </div>
-                  <div className="grid gap-4 p-6 md:grid-cols-2 lg:grid-cols-3">
+                  <div className="grid gap-4 p-4 sm:p-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
                     {visibleItems.map((item) => {
                       // 型安全性を確保
                       const priorityDisplay = (() => {
@@ -405,7 +405,7 @@ export default function BucketListPage({ loaderData }: Route.ComponentProps) {
                       return (
                       <div 
                         key={item.id}
-                        className="border border-gray-200 rounded-lg p-4 hover:shadow-md hover:border-blue-300 transition-all cursor-pointer min-h-[120px] flex flex-col"
+                        className="border border-gray-200 rounded-lg p-4 sm:p-5 hover:shadow-md hover:border-blue-300 transition-all cursor-pointer min-h-[120px] sm:min-h-[140px] flex flex-col"
                         onClick={() => openDetailDialog(item)}
                       >
                         {/* タイトルとバッジ */}

--- a/app/routes/dashboard/dashboard.tsx
+++ b/app/routes/dashboard/dashboard.tsx
@@ -90,21 +90,21 @@ export default function DashboardPage({ loaderData }: Route.ComponentProps) {
     <AuthenticatedLayout title="ダッシュボード">
       <div className="container mx-auto px-4 py-8 pb-12">
         <div className="mb-8">
-          <div className="flex justify-between items-center mb-6">
+          <div className="flex flex-col space-y-4 mb-6 md:flex-row md:justify-between md:items-center md:space-y-0">
             <div>
-              <h1 className="text-3xl font-bold text-gray-900">
+              <h1 className="text-2xl md:text-3xl font-bold text-gray-900">
                 ダッシュボード
               </h1>
               <p className="text-gray-600 mt-2">
                 あなたのやりたいことの達成状況を一覧で確認できます
               </p>
             </div>
-            <div className="space-x-2">
+            <div className="flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2">
               <Link to="/bucket-list/add">
-                <Button>+ 新しく追加</Button>
+                <Button className="w-full sm:w-auto">+ 新しく追加</Button>
               </Link>
               <Link to="/bucket-list">
-                <Button variant="outline">やりたいこと一覧</Button>
+                <Button variant="outline" className="w-full sm:w-auto">やりたいこと一覧</Button>
               </Link>
             </div>
           </div>
@@ -120,7 +120,7 @@ export default function DashboardPage({ loaderData }: Route.ComponentProps) {
           {/* 最近の達成とこれからの予定 */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
             {/* 最近完了した項目 */}
-            <div className="bg-white rounded-lg shadow p-6">
+            <div className="bg-white rounded-lg shadow p-4 sm:p-6">
               <h2 className="text-lg font-semibold text-gray-900 mb-4">
                 🎉 最近の達成
               </h2>
@@ -172,7 +172,7 @@ export default function DashboardPage({ loaderData }: Route.ComponentProps) {
             </div>
 
             {/* 期限が近い項目 */}
-            <div className="bg-white rounded-lg shadow p-6">
+            <div className="bg-white rounded-lg shadow p-4 sm:p-6">
               <h2 className="text-lg font-semibold text-gray-900 mb-4">
                 ⏰ 期限が近い項目
               </h2>
@@ -244,29 +244,29 @@ export default function DashboardPage({ loaderData }: Route.ComponentProps) {
             <h2 className="text-lg font-semibold text-gray-900 mb-4">
               🚀 クイックアクション
             </h2>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
               <Link to="/bucket-list/add">
-                <div className="text-center p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+                <div className="text-center p-4 sm:p-6 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors min-h-[80px] sm:min-h-[100px] flex flex-col justify-center items-center">
                   <div className="text-2xl mb-2">➕</div>
-                  <div className="text-sm font-medium">新規追加</div>
+                  <div className="text-xs sm:text-sm font-medium">新規追加</div>
                 </div>
               </Link>
               <Link to="/bucket-list?status=in_progress">
-                <div className="text-center p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+                <div className="text-center p-4 sm:p-6 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors min-h-[80px] sm:min-h-[100px] flex flex-col justify-center items-center">
                   <div className="text-2xl mb-2">🔄</div>
-                  <div className="text-sm font-medium">進行中を確認</div>
+                  <div className="text-xs sm:text-sm font-medium">進行中を確認</div>
                 </div>
               </Link>
               <Link to="/public">
-                <div className="text-center p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+                <div className="text-center p-4 sm:p-6 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors min-h-[80px] sm:min-h-[100px] flex flex-col justify-center items-center">
                   <div className="text-2xl mb-2">👥</div>
-                  <div className="text-sm font-medium">みんなのリスト</div>
+                  <div className="text-xs sm:text-sm font-medium">みんなのリスト</div>
                 </div>
               </Link>
               <Link to="/bucket-list?status=completed">
-                <div className="text-center p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+                <div className="text-center p-4 sm:p-6 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors min-h-[80px] sm:min-h-[100px] flex flex-col justify-center items-center">
                   <div className="text-2xl mb-2">🏆</div>
-                  <div className="text-sm font-medium">達成済みを見る</div>
+                  <div className="text-xs sm:text-sm font-medium">達成済みを見る</div>
                 </div>
               </Link>
             </div>

--- a/app/shared/layouts/authenticated-layout.tsx
+++ b/app/shared/layouts/authenticated-layout.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router";
 import { useAuth } from "~/features/auth";
-import { Button } from "~/components/ui/button";
+import { Button, MobileMenu } from "~/components/ui";
 
 interface AuthenticatedLayoutProps {
   children: React.ReactNode;
@@ -56,21 +56,31 @@ export function AuthenticatedLayout({
       <nav className="bg-white shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16">
+            {/* ロゴ・タイトル */}
             <div className="flex items-center">
               <Link to="/">
-                <h1 className="text-xl font-semibold">人生でやりたいこと</h1>
+                <h1 className="text-lg sm:text-xl font-semibold text-gray-900 hover:text-gray-700 transition-colors">
+                  人生でやりたいこと
+                </h1>
               </Link>
             </div>
-            <div className="flex items-center space-x-4">
-              {loading ? (
-                <span className="text-gray-500">読み込み中...</span>
-              ) : user ? (
-                <span className="text-gray-700">
-                  こんにちは、{user.email}さん
-                </span>
-              ) : (
-                <span className="text-gray-500">認証情報を取得中...</span>
-              )}
+
+            {/* デスクトップナビゲーション */}
+            <div className="hidden md:flex items-center space-x-4">
+              {/* ユーザー情報（デスクトップのみ） */}
+              <div className="text-sm text-gray-700">
+                {loading ? (
+                  <span className="text-gray-500">読み込み中...</span>
+                ) : user ? (
+                  <span className="max-w-48 truncate">
+                    こんにちは、{user.email}さん
+                  </span>
+                ) : (
+                  <span className="text-gray-500">認証情報を取得中...</span>
+                )}
+              </div>
+              
+              {/* ナビゲーションボタン */}
               <Link to="/dashboard">
                 <Button variant="outline" size="sm">
                   ダッシュボード
@@ -89,10 +99,20 @@ export function AuthenticatedLayout({
               <Button
                 onClick={handleSignOut}
                 variant="outline"
+                size="sm"
                 disabled={isSigningOut || loading}
               >
                 {isSigningOut ? "ログアウト中..." : "ログアウト"}
               </Button>
+            </div>
+
+            {/* モバイルナビゲーション */}
+            <div className="md:hidden flex items-center">
+              <MobileMenu
+                user={user}
+                onSignOut={handleSignOut}
+                isSigningOut={isSigningOut || loading}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Phase 1: モバイルナビゲーション実装
- ハンバーガーメニューコンポーネント作成 (MobileMenu)
- AuthenticatedLayout改修でデスクトップ/モバイル切り替え
- スライドアウトドロワーとオーバーレイ実装

Phase 2: ページヘッダー改善
- ダッシュボード・BucketListヘッダーのレスポンシブ対応
- ボタン配置の最適化 (モバイル時縦配置、デスクトップ時横配置)
- タイトルとボタンサイズの調整

Phase 3: コンテンツ最適化
- カードグリッドレイアウト改善 (1→2→3列)
- 統計コンポーネントのモバイル最適化
- タッチターゲットとスペーシング調整
- フィルターセクションの改善

🤖 Generated with [Claude Code](https://claude.ai/code)