### PR TITLE
fix: ホームページのナビゲーション対応とハンバーガーメニュー統一

### DIFF
--- a/app/components/ui/mobile-menu.tsx
+++ b/app/components/ui/mobile-menu.tsx
@@ -21,7 +21,7 @@ export function MobileMenu({ user, onSignOut, isSigningOut }: MobileMenuProps) {
       {/* ハンバーガーメニューボタン */}
       <button
         onClick={toggleMenu}
-        className="md:hidden p-2 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="p-2 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
         aria-label="メニューを開く"
       >
         <svg
@@ -46,14 +46,14 @@ export function MobileMenu({ user, onSignOut, isSigningOut }: MobileMenuProps) {
       {/* オーバーレイ */}
       {isOpen && (
         <div
-          className="md:hidden fixed inset-0 bg-black bg-opacity-50 z-40"
+          className="fixed inset-0 bg-black bg-opacity-50 z-40"
           onClick={closeMenu}
         />
       )}
 
       {/* スライドアウトメニュー */}
       <div
-        className={`md:hidden fixed top-0 right-0 h-full w-64 bg-white shadow-lg transform transition-transform duration-300 ease-in-out z-50 ${
+        className={`fixed top-0 right-0 h-full w-64 bg-white shadow-lg transform transition-transform duration-300 ease-in-out z-50 ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
       >

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Route } from "./+types/home";
 import { Link } from "react-router";
-import { Button } from "~/components/ui/button";
+import { Button, MobileMenu } from "~/components/ui";
 import { useAuth } from "~/features/auth";
 import { AppLayout } from "~/shared/layouts";
 
@@ -36,27 +36,11 @@ export default function HomePage() {
   }
 
   const navigationContent = user ? (
-    <>
-      <span className="text-gray-700">
-        こんにちは、{user.email}さん
-      </span>
-      <Link to="/dashboard">
-        <Button variant="outline">ダッシュボード</Button>
-      </Link>
-      <Link to="/bucket-list">
-        <Button variant="outline">やりたいこと一覧</Button>
-      </Link>
-      <Link to="/public">
-        <Button variant="outline">みんなのやりたいこと</Button>
-      </Link>
-      <Button
-        onClick={handleSignOut}
-        variant="outline"
-        disabled={isSigningOut}
-      >
-        {isSigningOut ? "ログアウト中..." : "ログアウト"}
-      </Button>
-    </>
+    <MobileMenu
+      user={user}
+      onSignOut={handleSignOut}
+      isSigningOut={isSigningOut}
+    />
   ) : (
     <>
       <Link to="/login">

--- a/app/shared/layouts/app-layout.tsx
+++ b/app/shared/layouts/app-layout.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router";
+import { MobileMenu } from "~/components/ui";
 
 interface AppLayoutProps {
   children: React.ReactNode;

--- a/app/shared/layouts/authenticated-layout.tsx
+++ b/app/shared/layouts/authenticated-layout.tsx
@@ -65,49 +65,8 @@ export function AuthenticatedLayout({
               </Link>
             </div>
 
-            {/* デスクトップナビゲーション */}
-            <div className="hidden md:flex items-center space-x-4">
-              {/* ユーザー情報（デスクトップのみ） */}
-              <div className="text-sm text-gray-700">
-                {loading ? (
-                  <span className="text-gray-500">読み込み中...</span>
-                ) : user ? (
-                  <span className="max-w-48 truncate">
-                    こんにちは、{user.email}さん
-                  </span>
-                ) : (
-                  <span className="text-gray-500">認証情報を取得中...</span>
-                )}
-              </div>
-              
-              {/* ナビゲーションボタン */}
-              <Link to="/dashboard">
-                <Button variant="outline" size="sm">
-                  ダッシュボード
-                </Button>
-              </Link>
-              <Link to="/bucket-list">
-                <Button variant="outline" size="sm">
-                  やりたいこと一覧
-                </Button>
-              </Link>
-              <Link to="/public">
-                <Button variant="outline" size="sm">
-                  みんなのやりたいこと
-                </Button>
-              </Link>
-              <Button
-                onClick={handleSignOut}
-                variant="outline"
-                size="sm"
-                disabled={isSigningOut || loading}
-              >
-                {isSigningOut ? "ログアウト中..." : "ログアウト"}
-              </Button>
-            </div>
-
-            {/* モバイルナビゲーション */}
-            <div className="md:hidden flex items-center">
+            {/* ハンバーガーメニュー（全画面サイズ対応） */}
+            <div className="flex items-center">
               <MobileMenu
                 user={user}
                 onSignOut={handleSignOut}


### PR DESCRIPTION
- ホームページ(/)でもハンバーガーメニューが表示されるよう修正
- AuthenticatedLayoutのデスクトップナビゲーション完全削除
- MobileMenuを全画面サイズで統一表示(md:hidden制約削除)
- 認証済みユーザーは全ページで一貫したハンバーガーメニュー
- 未認証ユーザーはログイン・新規登録ボタン表示維持

🤖 Generated with [Claude Code](https://claude.ai/code)