### PR TITLE
fix: フッターレイアウトの修正

### DIFF
--- a/app/shared/layouts/app-layout.tsx
+++ b/app/shared/layouts/app-layout.tsx
@@ -15,7 +15,7 @@ export function AppLayout({
   navigationContent,
 }: AppLayoutProps) {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 flex flex-col">
       {showNavigation && (
         <nav className="bg-white shadow">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -35,7 +35,7 @@ export function AppLayout({
         </nav>
       )}
 
-      <main className={showNavigation ? "" : "pt-0"}>
+      <main className={`flex-1 ${showNavigation ? "" : "pt-0"}`}>
         {title && (
           <div className="bg-white shadow-sm">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
@@ -47,7 +47,7 @@ export function AppLayout({
       </main>
       
       {/* フッター */}
-      <footer className="bg-white border-t border-gray-200 mt-auto">
+      <footer className="bg-white border-t border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="text-center text-sm text-gray-500">
             <p>

--- a/app/shared/layouts/authenticated-layout.tsx
+++ b/app/shared/layouts/authenticated-layout.tsx
@@ -52,7 +52,7 @@ export function AuthenticatedLayout({
   // ただし、ナビゲーションバーにはローディング表示を使用
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 flex flex-col">
       <nav className="bg-white shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16">
@@ -77,10 +77,10 @@ export function AuthenticatedLayout({
         </div>
       </nav>
 
-      <main>{children}</main>
+      <main className="flex-1">{children}</main>
       
       {/* フッター */}
-      <footer className="bg-white border-t border-gray-200 mt-auto">
+      <footer className="bg-white border-t border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="text-center text-sm text-gray-500">
             <p>


### PR DESCRIPTION
- Flexboxレイアウトに変更（min-h-screen + flex flex-col）
- mainにflex-1を追加してコンテンツ領域を自動拡張
- フッターが画面下部に適切に固定されるように修正
- mt-auto削除（flexboxによる自動配置）

トップページでの「ブラウザ下部との間の大きな空き」問題を解決

🤖 Generated with [Claude Code](https://claude.ai/code)